### PR TITLE
perf: ⚡️ add dataset att to identify stitches tag

### DIFF
--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -89,8 +89,14 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				})
 			}
 
+
+			const styleEl = document.createElement('style')
+			styleEl.dataset.stitches = 'true'
+
+			const sheet = root ? (root.head || root).appendChild(styleEl).sheet : createCSSMediaRule('', 'text/css')
+
 			groupSheet = {
-				sheet: root ? (root.head || root).appendChild(document.createElement('style')).sheet : createCSSMediaRule('', 'text/css'),
+				sheet,
 				rules: {},
 				reset,
 				toString() {


### PR DESCRIPTION
## This PR add a dataset attribute in style tag used by stitches to identify it.

`data-stitches=true`

### Result
![image](https://user-images.githubusercontent.com/12778450/138529602-5d284c31-acda-4a05-bb26-635ea196ffd9.png)

> This will be useful to create a workaround to use tools like hotjar and FullStory that doesn't support the CSSOM changes.

> Example with FullStory:
> https://user-images.githubusercontent.com/12778450/138529841-a3b0c6ac-3683-4f7c-a211-d7ffade55098.mov

The workaround to implement when you use a tool to recording sessions:
https://gist.github.com/oeduardoal/499923b72422e4222c5073ba2a708ad1

