### PR TITLE
feat: Added static "as" method

### DIFF
--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -17,31 +17,37 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 		const styled = (...args) => {
 			const cssComponent = css(...args)
-			const DefaultType = cssComponent[internal].type
 
-			const styledComponent = React.forwardRef((props, ref) => {
-				const Type = props && props.as || DefaultType
+			const createStyledComponent = DefaultType => {
+				const styledComponent = React.forwardRef((props, ref) => {
+					const Type = props && props.as || DefaultType
 
-				const { props: forwardProps, deferredInjector } = cssComponent(props)
+					const { props: forwardProps, deferredInjector } = cssComponent(props)
 
-				delete forwardProps.as
+					delete forwardProps.as
 
-				forwardProps.ref = ref
+					forwardProps.ref = ref
 
-				if (deferredInjector) {
-					return React.createElement(React.Fragment, null, React.createElement(Type, forwardProps), React.createElement(deferredInjector, null))
-				}
+					if (deferredInjector) {
+						return React.createElement(React.Fragment, null, React.createElement(Type, forwardProps), React.createElement(deferredInjector, null))
+					}
 
-				return React.createElement(Type, forwardProps)
-			})
+					return React.createElement(Type, forwardProps)
+				})
 
-			const toString = () => cssComponent.selector
+				const toString = () => cssComponent.selector
 
-			styledComponent.className = cssComponent.className
-			styledComponent.displayName = `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
-			styledComponent.selector = cssComponent.selector
-			styledComponent.toString = toString
-			styledComponent[internal] = cssComponent[internal]
+				styledComponent.className = cssComponent.className
+				styledComponent.displayName = `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
+				styledComponent.selector = cssComponent.selector
+				styledComponent.toString = toString
+				styledComponent[internal] = cssComponent[internal]
+
+				return styledComponent
+			}
+
+			const styledComponent = createStyledComponent(cssComponent[internal].type)
+			styledComponent.as = createStyledComponent
 
 			return styledComponent
 		}

--- a/packages/react/tests/component-as-method.js
+++ b/packages/react/tests/component-as-method.js
@@ -1,0 +1,34 @@
+import { createStitches } from '../src/index.js'
+
+describe('As method', () => {
+	test('The "as" method can be used or overridden', () => {
+		const { styled } = createStitches()
+		const component1 = styled()
+
+		const expression1 = component1.render()
+
+		expect(expression1.type).toBe('span')
+
+		const component2 = styled('div')
+		const expression2 = component2.render()
+
+		expect(expression2.type).toBe('div')
+
+		const expression2a = component2.as('span').render()
+
+		expect(expression2a.type).toBe('span')
+	})
+
+	test('The "as" method is followed during extension', () => {
+		const { styled } = createStitches()
+		const component1 = styled('div')
+		const component2 = styled(component1)
+		const expression = component2.render()
+
+		expect(expression.type).toBe('div')
+
+		const expression2a = component2.as('span').render()
+
+		expect(expression2a.type).toBe('span')
+	})
+})

--- a/packages/react/types/styled-component.d.ts
+++ b/packages/react/types/styled-component.d.ts
@@ -47,6 +47,7 @@ export interface StyledComponent<
 
 	className: string
 	selector: string
+	as: <Type extends IntrinsicElementsKeys | React.ComponentType<any>>(as: Type) => StyledComponent<Type, Props, Media, CSS>
 
 	[$$StyledComponentType]: Type
 	[$$StyledComponentProps]: Props

--- a/packages/test/index.tsx
+++ b/packages/test/index.tsx
@@ -18,11 +18,16 @@ const DEFAULT_TAG = 'h1'
 const bla: CSS = {
 	background: '$amber1',
 }
- const Test = styled('div', bla)
+const Test = styled('div', bla)
 export type HeadingProps = React.ComponentProps<typeof DEFAULT_TAG> & { css?: CSS }
 
 // ref should be span element
 type ref = React.ElementRef<typeof Text>
+
+// should be inferred as a element
+const Link = Text.as('a')
+// should be inferred as button element
+const Button = Link.as('button')
 
 const Heading = React.forwardRef<React.ElementRef<typeof DEFAULT_TAG>, HeadingProps>((props, forwardedRef) => {
 	return (
@@ -35,6 +40,7 @@ const Heading = React.forwardRef<React.ElementRef<typeof DEFAULT_TAG>, HeadingPr
 			<Text as="div" onClick={(e: any) => { console.log(e.altKey) }} css={{ ...props.css, backgroundColor: '$red100', background: 'red', paddingLeft: 'initial'}} />
 			<Text as="div" onClick={(e: any) => { console.log(e.altKey) }} css={props.css} />
 			<Text as={DEFAULT_TAG} {...props} onClick={(e: any) => { console.log(e.altKey) }} ref={forwardedRef} />
+			<Link href="#" />
 		</>
 	)
 })


### PR DESCRIPTION
This is reopened suggestion of #207 

The old PR was closed because incompatible with the new codebase, so I've reimplemented it to fit the current codebase.

I still think this is the simplest solution to get away with the ["as props nightmare"](https://twitter.com/jjenzz/status/1423766700885954562) and made PR directly to demonstrate just how small and simple the changes are.