### PR TITLE
Fix CSS type for utils overshadowing properties

### DIFF
--- a/packages/core/tests/issue-921.ts
+++ b/packages/core/tests/issue-921.ts
@@ -1,0 +1,62 @@
+import { createStitches, PropertyValue, CSS } from '../types/index'
+
+const config = {
+	utils: {
+		background: (value: boolean | PropertyValue<'background'>) => {
+			if (typeof value === 'boolean') {
+				return value ? {
+					background: 'red'
+				} : {}
+			} else {
+				return {
+					background: value
+				}
+			}
+		}
+	},
+}
+
+const { css, globalCss } = createStitches(config)
+
+globalCss({
+	html: {
+		background: true
+	},
+	body: {
+		background: 'green'
+	},
+})
+
+const Component = css({
+	background: true,
+	'> *': {
+		background: 'green'
+	}
+})
+
+Component({
+	background: 'green',
+	'> *': {
+		background: true
+	}
+})
+
+css(Component, {
+	background: 'green'
+})
+
+css(Component, {
+	background: true
+})
+
+const style: CSS = {
+	background: true // expect error
+}
+
+const style2: CSS<typeof config> = {
+	background: true
+}
+
+const style3: CSS<typeof config> = {
+	background: 'green'
+}

--- a/packages/core/types/css-util.d.ts
+++ b/packages/core/types/css-util.d.ts
@@ -27,7 +27,7 @@ export type CSS<
 	}
 	// known property styles
 	& {
-		[K in keyof CSSProperties]?: (
+		[K in keyof CSSProperties as K extends keyof Utils ? never : K]?: (
 			| ValueByPropertyName<K>
 			| TokenByPropertyName<K, Theme, ThemeMap>
 			| Native.Globals

--- a/packages/react/tests/issue-921.tsx
+++ b/packages/react/tests/issue-921.tsx
@@ -1,0 +1,81 @@
+import { createStitches, PropertyValue, CSS } from '../types/index'
+
+const config = {
+	utils: {
+		background: (value: boolean | PropertyValue<'background'>) => {
+			if (typeof value === 'boolean') {
+				return value ? {
+					background: 'red'
+				} : {}
+			} else {
+				return {
+					background: value
+				}
+			}
+		}
+	},
+}
+
+const { css, globalCss, styled } = createStitches(config)
+
+globalCss({
+	html: {
+		background: true
+	},
+	body: {
+		background: 'green'
+	},
+})
+
+const CComponent = css({
+	background: true,
+	'> *': {
+		background: 'green'
+	}
+})
+
+CComponent({
+	background: 'green',
+	'> *': {
+		background: true
+	}
+})
+
+css(CComponent, {
+	background: 'green'
+})
+
+css(CComponent, {
+	background: true
+})
+
+const SComponent = styled('div', {
+	background: 'green',
+	'> *': {
+		background: true
+	}
+})
+
+void function Test() {
+	return (
+		<SComponent css={{
+				background: true,
+				'> *': {
+					background: 'green'
+				}
+			}}
+		/>
+	)
+}
+
+const style: CSS = {
+	background: true // expect error
+}
+
+const style2: CSS<typeof config> = {
+	background: true
+}
+
+const style3: CSS<typeof config> = {
+	background: 'green'
+}

--- a/packages/react/types/css-util.d.ts
+++ b/packages/react/types/css-util.d.ts
@@ -27,7 +27,7 @@ export type CSS<
 	}
 	// known property styles
 	& {
-		[K in keyof CSSProperties]?: (
+		[K in keyof CSSProperties as K extends keyof Utils ? never : K]?: (
 			| ValueByPropertyName<K>
 			| TokenByPropertyName<K, Theme, ThemeMap>
 			| Native.Globals


### PR DESCRIPTION
When util's and property's names clash the util's type should take precedence.

Fixes #921

BTW type testing doesn't seem to work, the tests will pass regardless of the typing.