### PR TITLE
Fix `as` prop is not forwarded to target Component

### DIFF
--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -11,7 +11,7 @@ import { createCssFunction } from '../../../core/src/features/css.js'
 const createCssFunctionMap = createMemo()
 
 /** Returns a function that applies component styles. */
-export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }) => (
+export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }) =>
 	createCssFunctionMap(config, () => {
 		const css = createCssFunction(config, sheet)
 
@@ -19,12 +19,16 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			const cssComponent = css(...args)
 			const DefaultType = cssComponent[internal].type
 
+			const isHostComponent = typeof DefaultType === 'string'
+
 			const styledComponent = React.forwardRef((props, ref) => {
-				const Type = props && props.as || DefaultType
+				const Type = !isHostComponent ? DefaultType : (props && props.as) || DefaultType
 
 				const { props: forwardProps, deferredInjector } = cssComponent(props)
 
-				delete forwardProps.as
+				if (isHostComponent) {
+					delete forwardProps.as
+				}
 
 				forwardProps.ref = ref
 
@@ -48,4 +52,3 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 		return styled
 	})
-)

--- a/packages/react/tests/component-as-props-react.js
+++ b/packages/react/tests/component-as-props-react.js
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import * as renderer from 'react-test-renderer'
+
+import { createStitches } from '../src/index.js'
+
+describe('React Component with As prop', () => {
+	test('The "as" property works in composition of Styled Components', () => {
+		const { styled, getCssText } = createStitches()
+
+		const StyledButton = styled('button', {
+			color: 'red',
+		})
+
+		const CustomStyledButton = styled(StyledButton, {
+			color: 'white',
+			backgroundColor: 'blue',
+		})
+
+		const vdom = renderer.create(React.createElement(CustomStyledButton, { as: 'a' }, 'Hello, World!'))
+
+		expect(vdom.toJSON()).toEqual({
+			type: 'a',
+			props: {
+				className: 'c-gmqXFB c-jOiKxS',
+			},
+			children: ['Hello, World!'],
+		})
+
+		expect(getCssText()).toBe(`--sxs{--sxs:2 c-gmqXFB c-jOiKxS}@media{.c-gmqXFB{color:red}.c-jOiKxS{color:white;background-color:blue}}`)
+	})
+
+	test('The "as" property is forwarded to target Component of Styled Component', () => {
+		const { styled, getCssText } = createStitches()
+
+		const StyledButton = styled('button', {
+			color: 'red',
+		})
+
+		const Button = (props) => {
+			return React.createElement(StyledButton, props)
+		}
+
+		const CustomStyledButton = styled(Button, {
+			backgroundColor: 'blue',
+		})
+
+		const vdom = renderer.create(React.createElement(CustomStyledButton, { as: 'a' }, 'Hello, World!'))
+
+		expect(vdom.toJSON()).toEqual({
+			type: 'a',
+			props: {
+				className: 'c-gmqXFB c-fNnBJi',
+			},
+			children: ['Hello, World!'],
+		})
+
+		expect(getCssText()).toBe(`--sxs{--sxs:2 c-fNnBJi c-gmqXFB}@media{.c-gmqXFB{color:red}.c-fNnBJi{background-color:blue}}`)
+	})
+})


### PR DESCRIPTION
**Fixes:** https://github.com/modulz/stitches/issues/979

**Previous behaviour:**

```jsx
const StyledButton = styled('button', {
  color: 'red',
})

const Button = (props) => {
  return React.createElement(StyledButton, props)
}

const CustomStyledButton = styled(Button, {
  backgroundColor: 'blue',
})

// Renders: <Button {...} />
<CustomStyledButton />
// Renders: <a {...} />
<CustomStyledButton as="a" />
```

**New behaviour:**

```jsx
const StyledButton = styled('button', {
  color: 'red',
})

const Button = (props) => {
  return React.createElement(StyledButton, props)
}

const CustomStyledButton = styled(Button, {
  backgroundColor: 'blue',
})

// Renders: <Button {...} />
<CustomStyledButton />
// Renders: <Button as="a" {...} />
<CustomStyledButton as="a" />
```