### PR TITLE
feat: Optional token scale prefix

### DIFF
--- a/packages/core/src/convert/toCssRules.js
+++ b/packages/core/src/convert/toCssRules.js
@@ -53,7 +53,7 @@ export const toCssRules = (
 
 				for (data of datas) {
 					const camelName = toCamelCase(name)
-					
+
 					/** Whether the current data represents a nesting rule, which is a plain object whose key is not already a util. */
 					const isRuleLike = typeof data === 'object' && data && data.toString === toStringOfObject && (!config.utils[camelName] || !selectors.length)
 
@@ -127,7 +127,7 @@ export const toCssRules = (
 							: toTokenizedValue(
 								toSizingValue(camelName, data == null ? '' : data),
 								config.prefix,
-								config.themeMap[camelName]
+								config.hasScalePrefix ? config.themeMap[camelName] : ''
 							)
 						)
 

--- a/packages/core/src/createStitches.js
+++ b/packages/core/src/createStitches.js
@@ -21,6 +21,7 @@ export const createStitches = (config) => {
 
 		// internal configuration
 		const prefix = 'prefix' in initConfig ? String(initConfig.prefix) : ''
+		const hasScalePrefix = 'hasScalePrefix' in initConfig ? String(initConfig.hasScalePrefix) : true
 		const media = typeof initConfig.media === 'object' && initConfig.media || {}
 		const root = typeof initConfig.root === 'object' ? initConfig.root || null : globalThis.document || null
 		const theme = typeof initConfig.theme === 'object' && initConfig.theme || {}
@@ -30,6 +31,7 @@ export const createStitches = (config) => {
 		/** External configuration. */
 		const config = {
 			prefix,
+			hasScalePrefix,
 			media,
 			theme,
 			themeMap,
@@ -52,6 +54,7 @@ export const createStitches = (config) => {
 			sheet,
 			config,
 			prefix,
+			hasScalePrefix,
 			getCssText: sheet.toString,
 			toString: sheet.toString,
 		}

--- a/packages/core/src/createStitches.js
+++ b/packages/core/src/createStitches.js
@@ -21,7 +21,7 @@ export const createStitches = (config) => {
 
 		// internal configuration
 		const prefix = 'prefix' in initConfig ? String(initConfig.prefix) : ''
-		const hasScalePrefix = 'hasScalePrefix' in initConfig ? String(initConfig.hasScalePrefix) : true
+		const hasScalePrefix = 'hasScalePrefix' in initConfig ? Boolean(initConfig.hasScalePrefix) : true
 		const media = typeof initConfig.media === 'object' && initConfig.media || {}
 		const root = typeof initConfig.root === 'object' ? initConfig.root || null : globalThis.document || null
 		const theme = typeof initConfig.theme === 'object' && initConfig.theme || {}

--- a/packages/core/src/features/createTheme.js
+++ b/packages/core/src/features/createTheme.js
@@ -34,7 +34,7 @@ export const createCreateThemeFunction = (
 				const propertyName = `--${toTailDashed(config.prefix)}${toTailDashed(config.hasScalePrefix ? scale : '')}${token}`
 				const propertyValue = toTokenizedValue(String(style[scale][token]), config.prefix, config.hasScalePrefix ? scale : '')
 
-				themeObject[scale][token] = new ThemeToken(token, propertyValue,scale, config.prefix)
+				themeObject[scale][token] = new ThemeToken(token, propertyValue, config.hasScalePrefix ? scale : '', config.prefix)
 
 				cssProps.push(`${propertyName}:${propertyValue}`)
 

--- a/packages/core/src/features/createTheme.js
+++ b/packages/core/src/features/createTheme.js
@@ -31,10 +31,12 @@ export const createCreateThemeFunction = (
 			themeObject[scale] = {}
 
 			for (const token in style[scale]) {
-				const propertyName = `--${toTailDashed(config.prefix)}${scale}-${token}`
-				const propertyValue = toTokenizedValue(String(style[scale][token]), config.prefix, scale)
+				const scalePrefix = config.hasScalePrefix ? scale : ''
 
-				themeObject[scale][token] = new ThemeToken(token, propertyValue, scale, config.prefix)
+				const propertyName = `--${toTailDashed(config.prefix)}${toTailDashed(scalePrefix)}${token}`
+				const propertyValue = toTokenizedValue(String(style[scalePrefix][token]), config.prefix, scalePrefix)
+
+				themeObject[scale][token] = new ThemeToken(token, propertyValue, scalePrefix, config.prefix)
 
 				cssProps.push(`${propertyName}:${propertyValue}`)
 			}

--- a/packages/core/src/features/createTheme.js
+++ b/packages/core/src/features/createTheme.js
@@ -31,14 +31,16 @@ export const createCreateThemeFunction = (
 			themeObject[scale] = {}
 
 			for (const token in style[scale]) {
-				const scalePrefix = config.hasScalePrefix ? scale : ''
+				const propertyName = `--${toTailDashed(config.prefix)}${toTailDashed(config.hasScalePrefix ? scale : '')}${token}`
+				const propertyValue = toTokenizedValue(String(style[scale][token]), config.prefix, config.hasScalePrefix ? scale : '')
 
-				const propertyName = `--${toTailDashed(config.prefix)}${toTailDashed(scalePrefix)}${token}`
-				const propertyValue = toTokenizedValue(String(style[scalePrefix][token]), config.prefix, scalePrefix)
-
-				themeObject[scale][token] = new ThemeToken(token, propertyValue, scalePrefix, config.prefix)
+				themeObject[scale][token] = new ThemeToken(token, propertyValue,scale, config.prefix)
 
 				cssProps.push(`${propertyName}:${propertyValue}`)
+
+				if (config.prefix == "dy") {
+					console.log({ propertyName, propertyValue, ...themeObject })
+				}
 			}
 		}
 

--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -6,6 +6,9 @@ declare namespace ConfigType {
 	/** Prefix interface. */
 	export type Prefix<T = ''> = T extends string ? T: string
 
+	/** HasScalePrefix interface. */
+	export type HasScalePrefix<T = true> = T extends boolean ? T: boolean
+
 	/** Media interface. */
 	export type Media<T = {}> = {
 		[name in keyof T]: T[name] extends string ? T[name] : string
@@ -194,6 +197,7 @@ export interface DefaultThemeMap {
 export type CreateStitches = {
 	<
 		Prefix extends string = '',
+		HasScalePrefix extends boolean = true,
 		Media extends {} = {},
 		Theme extends {} = {},
 		ThemeMap extends {} = DefaultThemeMap,
@@ -201,10 +205,11 @@ export type CreateStitches = {
 	>(
 		config?: {
 			prefix?: ConfigType.Prefix<Prefix>
+			hasScalePrefix?: ConfigType.HasScalePrefix<HasScalePrefix>
 			media?: ConfigType.Media<Media>
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>
 			utils?: ConfigType.Utils<Utils>
 		}
-	): Stitches<Prefix, Media, Theme, ThemeMap, Utils>
+	): Stitches<Prefix, HasScalePrefix, Media, Theme, ThemeMap, Utils>
 }

--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -9,6 +9,7 @@ export type RemoveIndex<T> = {[k in keyof T as string extends k ? never : number
 /** Stitches interface. */
 export default interface Stitches<
 	Prefix extends string = '',
+	HasScalePrefix extends boolean = true,
 	Media extends {} = {},
 	Theme extends {} = {},
 	ThemeMap extends {} = {},
@@ -16,6 +17,7 @@ export default interface Stitches<
 > {
 	config: {
 		prefix: Prefix
+		hasScalePrefix: HasScalePrefix
 		media: Media
 		theme: Theme
 		themeMap: ThemeMap
@@ -110,7 +112,7 @@ export default interface Stitches<
 			)
 	}
 	theme:
-		string 
+		string
 		& {
 			className: string
 			selector: string

--- a/packages/react/types/config.d.ts
+++ b/packages/react/types/config.d.ts
@@ -6,6 +6,9 @@ declare namespace ConfigType {
 	/** Prefix interface. */
 	export type Prefix<T = ''> = T extends string ? T: string
 
+	/** HasScalePrefix interface. */
+	export type HasScalePrefix<T = true> = T extends boolean ? T: boolean
+
 	/** Media interface. */
 	export type Media<T = {}> = {
 		[name in keyof T]: T[name] extends string ? T[name] : string
@@ -194,6 +197,7 @@ export interface DefaultThemeMap {
 export type CreateStitches = {
 	<
 		Prefix extends string = '',
+		HasScalePrefix extends boolean = true,
 		Media extends {} = {},
 		Theme extends {} = {},
 		ThemeMap extends {} = DefaultThemeMap,
@@ -201,10 +205,11 @@ export type CreateStitches = {
 	>(
 		config?: {
 			prefix?: ConfigType.Prefix<Prefix>
+			hasScalePrefix?: ConfigType.HasScalePrefix<HasScalePrefix>
 			media?: ConfigType.Media<Media>
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>
 			utils?: ConfigType.Utils<Utils>
 		}
-	): Stitches<Prefix, Media, Theme, ThemeMap, Utils>
+	): Stitches<Prefix, HasScalePrefix, Media, Theme, ThemeMap, Utils>
 }

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -9,6 +9,7 @@ export type RemoveIndex<T> = {[k in keyof T as string extends k ? never : number
 /** Stitches interface. */
 export default interface Stitches<
 	Prefix extends string = '',
+	HasScalePrefix extends boolean = true,
 	Media extends {} = {},
 	Theme extends {} = {},
 	ThemeMap extends {} = {},
@@ -16,6 +17,7 @@ export default interface Stitches<
 > {
 	config: {
 		prefix: Prefix
+		hasScalePrefix: HasScalePrefix
 		media: Media
 		theme: Theme
 		themeMap: ThemeMap
@@ -110,7 +112,7 @@ export default interface Stitches<
 			)
 	}
 	theme:
-		string 
+		string
 		& {
 			className: string
 			selector: string
@@ -208,7 +210,7 @@ export default interface Stitches<
 				| React.ComponentType<any>
 				| Util.Function
 				| { [name: string]: unknown }
-			)[], 
+			)[],
 			CSS = CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
 		>(
 			type: Type,

--- a/packages/test/built-types/stitches.config.d.ts
+++ b/packages/test/built-types/stitches.config.d.ts
@@ -4250,6 +4250,7 @@ export declare const styled: <Type extends import("@stitches/react/types/util").
     name: string;
 }, config: {
     prefix: "";
+    hasScalePrefix: true;
     media: {
         bp1: "(min-width: 520px)";
         bp2: "(min-width: 900px)";


### PR DESCRIPTION
This PR adds the ability to remove scale from CSS variables.

i.g.:

Currently:
```jsx
export const { styled, css, config, theme, createTheme } = createStitches({
  theme: {
    colors: {
      "my-pink": "#FFBDC9"
    },
  },
});

the injected CSS variable is: $colors-my-pink: #FFBDC9
```

Proposed feature:
```jsx
export const { styled, css, config, theme, createTheme } = createStitches({
  hasScalePrefix: false, // default true
  theme: {
    colors: {
      "my-pink": "#FFBDC9"
    },
  },
});

the injected CSS variable is: $my-pink: #FFBDC9
```