### PR TITLE
feat: Support for external CSS preprecessors

### DIFF
--- a/packages/core/src/convert/toCssRules.js
+++ b/packages/core/src/convert/toCssRules.js
@@ -145,7 +145,7 @@ export const toCssRules = (
 		currentRule = undefined
 	}
 
-	walk(style, selectors, conditions)
+	walk(config.cssPreProcessor(style), selectors, conditions)
 }
 
 const toCssString = (/** @type {string[]} */ declarations, /** @type {string[]} */ selectors, /** @type {string[]} */ conditions) => (

--- a/packages/core/src/createStitches.js
+++ b/packages/core/src/createStitches.js
@@ -26,6 +26,7 @@ export const createStitches = (config) => {
 		const theme = typeof initConfig.theme === 'object' && initConfig.theme || {}
 		const themeMap = typeof initConfig.themeMap === 'object' && initConfig.themeMap || { ...defaultThemeMap }
 		const utils = typeof initConfig.utils === 'object' && initConfig.utils || {}
+		const cssPreProcessor = typeof initConfig.cssPreProcessor === 'function' && initConfig.cssPreProcessor || ((styles) => styles)
 
 		/** External configuration. */
 		const config = {
@@ -34,6 +35,7 @@ export const createStitches = (config) => {
 			theme,
 			themeMap,
 			utils,
+			cssPreProcessor,
 		}
 
 		/** Internal stylesheet. */

--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -6,6 +6,9 @@ declare namespace ConfigType {
 	/** Prefix interface. */
 	export type Prefix<T = ''> = T extends string ? T: string
 
+	/** CSS pre-processor interface. */
+	export type CssPreProcessor = (styles: Record<string, any>) => Record<string, any>
+
 	/** Media interface. */
 	export type Media<T = {}> = {
 		[name in keyof T]: T[name] extends string ? T[name] : string
@@ -201,6 +204,7 @@ export type CreateStitches = {
 	>(
 		config?: {
 			prefix?: ConfigType.Prefix<Prefix>
+			cssPreProcessor?: ConfigType.CssPreProcessor
 			media?: ConfigType.Media<Media>
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>

--- a/packages/react/types/config.d.ts
+++ b/packages/react/types/config.d.ts
@@ -6,6 +6,9 @@ declare namespace ConfigType {
 	/** Prefix interface. */
 	export type Prefix<T = ''> = T extends string ? T: string
 
+	/** CSS pre-processor interface. */
+	export type CssPreProcessor = (styles: Record<string, any>) => Record<string, any>
+
 	/** Media interface. */
 	export type Media<T = {}> = {
 		[name in keyof T]: T[name] extends string ? T[name] : string
@@ -201,6 +204,7 @@ export type CreateStitches = {
 	>(
 		config?: {
 			prefix?: ConfigType.Prefix<Prefix>
+			cssPreProcessor?: ConfigType.CssPreProcessor
 			media?: ConfigType.Media<Media>
 			theme?: ConfigType.Theme<Theme>
 			themeMap?: ConfigType.ThemeMap<ThemeMap>


### PR DESCRIPTION
This tiny PR* adds support for external CSS preprocessors. Specifically, it allows devs to define a preprocessor function via their config, which will be called before Stitches walks through a style object.

Basically, this gives devs the power of _utils_, but everywhere, including when other devs (or consumers of your design system) use native CSS props instead of your custom utils.

## Rationale
_Utils_ are awesome, but you can only get that power through use of the util — if a consumer of your design system uses standard CSS properties, you have no way to add value there.

## Sample Use Case
I'm creating a design system that is insanely easy to localize, including for RTL languages. If a dev creates a style of `borderRadius: 0 $4 $4 0`, we can easily understand that this element has rounded top-right and bottom-right corners; that makes it easy to translate this to a RTL layout as `borderRadius: $4 0 0 $4`.

While this could be done with a custom util, the issue is that if a consumer of my design system uses the standard CSS prop `borderRadius`, I lose the ability to auto-translate directional styles for them.

Having an interface to the CSS objects before they get processed gives me the ability to translate all LTR directional styles into RTL directional styles, automagically.

## Proposed Interface
```TS
(styles: Record<string, any>) => Record<string, any>
```
Simple as can be. This PR includes a passthrough default function, in case a user doesn't define one.

---

*—I'd be happy to add some tests, and even write up some draft documentation, but didn't want to commit that time until I heard that the core team was willing to accept this feature.