### PR TITLE
feat(security): add nonce support for injected style tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IntelliJ
+.idea/

--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -1,3 +1,5 @@
+import { getNonce } from './utility/getNonce'
+
 /** @typedef {import('./sheet').RuleGroup} RuleGroup */
 /** @typedef {import('./sheet').RuleGroupNames} RuleGroupNames */
 /** @typedef {import('./sheet').SheetGroup} SheetGroup */
@@ -137,8 +139,20 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				})
 			}
 
+			const createSheet = () => {
+				if (!root) {
+					return createCSSMediaRule('', 'text/css')
+				}
+				const styleEl = document.createElement('style')
+				const nonce = getNonce()
+				if (nonce) {
+					styleEl.setAttribute('nonce', nonce)
+				}
+				return (root.head || root).appendChild(styleEl).sheet
+			}
+
 			groupSheet = {
-				sheet: root ? (root.head || root).appendChild(document.createElement('style')).sheet : createCSSMediaRule('', 'text/css'),
+				sheet: createSheet(),
 				rules: {},
 				reset,
 				toString,
@@ -187,9 +201,9 @@ const addApplyToGroup = (/** @type {RuleGroup} */ group) => {
 /** Pending rules for injection */
 const $pr = Symbol()
 
-/** 
+/**
  * When a stitches component is extending some other random react component,
- * it’s gonna create a react component (Injector) using this function and then render it after the children, 
+ * it’s gonna create a react component (Injector) using this function and then render it after the children,
  * this way, we would force the styles of the wrapper to be injected after the wrapped component
  */
 export const createRulesInjectionDeferrer = (globalSheet) => {

--- a/packages/core/src/utility/getNonce.js
+++ b/packages/core/src/utility/getNonce.js
@@ -1,0 +1,5 @@
+export const getNonce = () => {
+	if (typeof window.__webpack_nonce__ !== 'undefined') return window.__webpack_nonce__
+	if (typeof window.nonce !== 'undefined') return window.nonce
+	return null
+}


### PR DESCRIPTION
## Problem
When trying to enforce strict rules about which content is allowed on a specific page, a Content Security Policy (CSP) is the way to go.

The Stitches library currently injects all of their style scripts as an inline style to the DOM. For this to function, a CSP would need to contain `style-src: unsafe-inline` for the app/library to function properly. As the attribute name implies, this is unsafe and not the recommended way of building a secure app.

There is the concept of nonce attributes that allows inline style/script tags to be executed if the nonce matches the CSP header. The rule would look something like this `style-src: 'self' 'nonce-<injected-id>'` If Stitches checks for and sets this nonce, security minded apps can get rid of the unsafe-inline setting and consume this library.

## Solution

Luckily, WebPack is already supporting the concept of a global `__webpack_nonce__ `variable. Once set, all dynamically injected code created by WebPack will have a nonce attribute with the correct value. Some apps may not be using WebPack and may prefer to set the nonce in a different property on window. 

If the `__webpack_nonce__` or `window.nonce` variable is set, pass the value to every generated style tag inside the nonce attribute of the style tag.  All the magic happens in the new `createSheet` function I created that simply checks for a nonce existence and adds the nonce attribute with value if it exists.

I have tested this in a private repo and confirm it works as intended. See below that the global theme style tag now has the nonce attribute set on the inline style tag.
![Screen Shot 2022-04-12 at 1 27 29 PM](https://user-images.githubusercontent.com/6364918/163020199-d71d5edd-3ae5-4302-ae53-c8f9fd7f3a97.png)


### Further readings:

https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
https://developers.google.com/web/fundamentals/security/csp/
https://csp.withgoogle.com/docs/index.html