### PR TITLE
Add support for custom (human-friendly) class names

### DIFF
--- a/packages/core/src/features/css.js
+++ b/packages/core/src/features/css.js
@@ -28,6 +28,10 @@ const createCssFunctionMap = createMemo()
 /** Returns a function that applies component styles. */
 export const createCssFunction = (/** @type {Config} */ config, /** @type {SheetGroup} */ sheet) =>
 	createCssFunctionMap(config, () => (...args) => {
+		const last = args.length - 1
+		const hasCustomName = args[last] && typeof args[last] === 'object' && args[last].componentName
+		const componentName = hasCustomName ? args[last].componentName : null
+
 		/** @type {Internals} */
 		let internals = {
 			type: null,
@@ -54,7 +58,7 @@ export const createCssFunction = (/** @type {Config} */ config, /** @type {Sheet
 
 			// otherwise, add a new composer to this component
 			else {
-				internals.composers.add(createComposer(arg, config))
+				internals.composers.add(createComposer({componentName, ...arg}, config))
 			}
 		}
 
@@ -66,9 +70,11 @@ export const createCssFunction = (/** @type {Config} */ config, /** @type {Sheet
 	})
 
 /** Creates a composer from a configuration object. */
-const createComposer = (/** @type {InitComposer} */ { variants: initSingularVariants, compoundVariants: initCompoundVariants, defaultVariants: initDefaultVariants, ...style }, /** @type {Config} */ config) => {
+const createComposer = (/** @type {InitComposer} */ { variants: initSingularVariants, compoundVariants: initCompoundVariants, defaultVariants: initDefaultVariants, componentName, ...style }, /** @type {Config} */ config) => {
+	/** @type {string} */
+	const baseClass = componentName && componentName.length > 0 ? `${componentName}-${toHash(style)}` : toHash(style)
 	/** @type {string} Composer Unique Identifier. @see `{CONFIG_PREFIX}-?c-{STYLE_HASH}` */
-	const className = `${toTailDashed(config.prefix)}c-${toHash(style)}`
+	const className = `${toTailDashed(config.prefix)}c-${baseClass}`
 
 	/** @type {VariantTuple[]} */
 	const singularVariants = []

--- a/packages/core/tests/named-components.js
+++ b/packages/core/tests/named-components.js
@@ -1,0 +1,50 @@
+import { createStitches } from '../src/index.js'
+
+describe('Composition', () => {
+	test('Renders an empty component', () => {
+		const { css, toString } = createStitches()
+		const generic = css.withName("Generic")()
+
+		expect(generic().props).toEqual({ className: 'c-Generic-PJLV' })
+		expect(toString()).toBe('')
+	})
+
+	test('Renders a component as the final composition by default', () => {
+		const { css, toString } = createStitches()
+		const Red = css.withName("Red")({ color: 'red' })
+		const Size14 = css.withName("Size14")({ fontSize: '14px' })
+		const Bold = css.withName("Bold")({ fontWeight: 'bold' })
+		const Title = css.withName("Title")(Red, Size14, Bold, { fontFamily: 'monospace' })
+
+		expect(Title.className).toBe('c-Red-gmqXFB')
+		expect(toString()).toBe('')
+		expect(String(Title)).toBe('c-Red-gmqXFB')
+		expect(toString()).toBe(
+			`--sxs{--sxs:2 c-Red-gmqXFB c-Size14-hzkWus c-Bold-cQFdVt c-Title-kngyIZ}@media{` +
+				`.c-Red-gmqXFB{color:red}` +
+				`.c-Size14-hzkWus{font-size:14px}` +
+				`.c-Bold-cQFdVt{font-weight:bold}` +
+				`.c-Title-kngyIZ{font-family:monospace}` +
+			`}`
+		)
+	})
+
+	test('Renders a component with all compositions', () => {
+		const { css, toString } = createStitches()
+		const Red = css.withName("Red")({ color: 'red' })
+		const Size14 = css.withName("Size14")({ fontSize: '14px' })
+		const Bold = css.withName("Bold")({ fontWeight: 'bold' })
+		const Title = css.withName("Title")(Red, Size14, Bold, { fontFamily: 'monospace' })
+
+		expect(Title().className).toBe('c-Red-gmqXFB c-Size14-hzkWus c-Bold-cQFdVt c-Title-kngyIZ')
+		expect(toString()).toBe(
+			`--sxs{--sxs:2 c-Red-gmqXFB c-Size14-hzkWus c-Bold-cQFdVt c-Title-kngyIZ}@media{` +
+				`.c-Red-gmqXFB{color:red}` +
+				`.c-Size14-hzkWus{font-size:14px}` +
+				`.c-Bold-cQFdVt{font-weight:bold}` +
+				`.c-Title-kngyIZ{font-family:monospace}` +
+			`}`
+		)
+	})
+})
+

--- a/packages/core/tests/universal-serialization.js
+++ b/packages/core/tests/universal-serialization.js
@@ -4,13 +4,13 @@ describe('Serialization', () => {
 	const sheet = createStitches()
 	const { css, getCssText, toString, createTheme } = sheet
 
-	const myComponent = css({
+	const myComponent = css.withName("myComponent")({
 		all: 'unset',
 		font: 'inherit',
 		margin: 0,
 		padding: '0.5em 1em',
 	})
-	const myComponentClassName = 'c-cLikna'
+	const myComponentClassName = 'c-myComponent-cLikna'
 
 	const myTheme = createTheme({
 		colors: {
@@ -46,7 +46,7 @@ describe('Serialization', () => {
 		expect(myTheme.selector).toBe(`.${myThemeClassName}`)
 	})
 
-	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{.${myThemeClassName}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-cLikna}@media{.${myComponentClassName}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
+	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{.${myThemeClassName}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-myComponent-cLikna}@media{.${myComponentClassName}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
 
 	test('Sheets implicitly return their cssText', () => {
 		expect(String(sheet)).toBe(sheetCssText)

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -37,14 +37,20 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 			const toString = () => cssComponent.selector
 
+			const last = args.length - 1
+			const hasCustomName = args[last] && typeof args[last] === 'object' && args[last].componentName
+			const componentName = hasCustomName ? args[last].componentName : null
+	
 			styledComponent.className = cssComponent.className
-			styledComponent.displayName = `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
+			styledComponent.displayName = componentName || `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
 			styledComponent.selector = cssComponent.selector
 			styledComponent.toString = toString
 			styledComponent[internal] = cssComponent[internal]
 
 			return styledComponent
 		}
+
+		styled.withName = (componentName, ...args) => styled(...args, { componentName })
 
 		return styled
 	})

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -10,13 +10,19 @@ import { createCssFunction } from '../../../core/src/features/css.js'
 
 const createCssFunctionMap = createMemo()
 
+/** @type {string | null} */
+let nameBuffer = null
+
 /** Returns a function that applies component styles. */
 export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }) => (
 	createCssFunctionMap(config, () => {
 		const css = createCssFunction(config, sheet)
 
 		const styled = (...args) => {
-			const cssComponent = css(...args)
+			const componentName = nameBuffer
+			nameBuffer = null
+
+			const cssComponent = css.withName(componentName)(...args)
 			const DefaultType = cssComponent[internal].type
 
 			const styledComponent = React.forwardRef((props, ref) => {
@@ -37,10 +43,6 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 			const toString = () => cssComponent.selector
 
-			const last = args.length - 1
-			const hasCustomName = args[last] && typeof args[last] === 'object' && args[last].componentName
-			const componentName = hasCustomName ? args[last].componentName : null
-	
 			styledComponent.className = cssComponent.className
 			styledComponent.displayName = componentName || `Styled.${DefaultType.displayName || DefaultType.name || DefaultType}`
 			styledComponent.selector = cssComponent.selector
@@ -50,7 +52,10 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			return styledComponent
 		}
 
-		styled.withName = (componentName, ...args) => styled(...args, { componentName })
+		styled.withName = (/** @type {string} */ componentName) => (...args) => {
+			nameBuffer = componentName
+			return styled(...args)
+		}
 
 		return styled
 	})

--- a/packages/react/tests/named-components.js
+++ b/packages/react/tests/named-components.js
@@ -1,0 +1,20 @@
+import { createStitches } from '../src/index.js'
+
+describe('Named Components', () => {
+	test('Renders an empty component', () => {
+		const { styled, getCssText } = createStitches()
+		const Generic = styled.withName("Generic")
+		expect(Generic.render().props).toEqual({ className: 'c-Generic-PJLV' })
+		expect(getCssText()).toBe('')
+	})
+
+	test('Renders a component with all compositions', () => {
+		const { styled, getCssText } = createStitches()
+		const Red = styled.withName("Red", { color: 'red' })
+		const Size14 = styled.withName("Size14", { fontSize: '14px' })
+		const Bold = styled.withName("Bold", { fontWeight: 'bold' })
+		const Title = styled.withName("Title", Red, Size14, Bold, { fontFamily: 'monospace' })
+		expect(Title.render().props.className).toBe('c-Red-gmqXFB c-Red-PJLV c-Size14-hzkWus c-Size14-PJLV c-Bold-cQFdVt c-Bold-PJLV c-Title-kngyIZ c-Title-PJLV')
+		expect(getCssText()).toBe('--sxs{--sxs:2 c-Red-gmqXFB c-Red-PJLV c-Size14-hzkWus c-Size14-PJLV c-Bold-cQFdVt c-Bold-PJLV c-Title-kngyIZ c-Title-PJLV}@media{.c-Red-gmqXFB{color:red}.c-Size14-hzkWus{font-size:14px}.c-Bold-cQFdVt{font-weight:bold}.c-Title-kngyIZ{font-family:monospace}}')
+	})
+})

--- a/packages/react/tests/named-components.js
+++ b/packages/react/tests/named-components.js
@@ -3,18 +3,18 @@ import { createStitches } from '../src/index.js'
 describe('Named Components', () => {
 	test('Renders an empty component', () => {
 		const { styled, getCssText } = createStitches()
-		const Generic = styled.withName("Generic")
+		const Generic = styled.withName("Generic")()
 		expect(Generic.render().props).toEqual({ className: 'c-Generic-PJLV' })
 		expect(getCssText()).toBe('')
 	})
 
 	test('Renders a component with all compositions', () => {
 		const { styled, getCssText } = createStitches()
-		const Red = styled.withName("Red", { color: 'red' })
-		const Size14 = styled.withName("Size14", { fontSize: '14px' })
-		const Bold = styled.withName("Bold", { fontWeight: 'bold' })
-		const Title = styled.withName("Title", Red, Size14, Bold, { fontFamily: 'monospace' })
-		expect(Title.render().props.className).toBe('c-Red-gmqXFB c-Red-PJLV c-Size14-hzkWus c-Size14-PJLV c-Bold-cQFdVt c-Bold-PJLV c-Title-kngyIZ c-Title-PJLV')
-		expect(getCssText()).toBe('--sxs{--sxs:2 c-Red-gmqXFB c-Red-PJLV c-Size14-hzkWus c-Size14-PJLV c-Bold-cQFdVt c-Bold-PJLV c-Title-kngyIZ c-Title-PJLV}@media{.c-Red-gmqXFB{color:red}.c-Size14-hzkWus{font-size:14px}.c-Bold-cQFdVt{font-weight:bold}.c-Title-kngyIZ{font-family:monospace}}')
+		const Red = styled.withName("Red")({ color: 'red' })
+		const Size14 = styled.withName("Size14")({ fontSize: '14px' })
+		const Bold = styled.withName("Bold")({ fontWeight: 'bold' })
+		const Title = styled.withName("Title")(Red, Size14, Bold, { fontFamily: 'monospace' })
+		expect(Title.render().props.className).toBe('c-Red-gmqXFB c-Size14-hzkWus c-Bold-cQFdVt c-Title-kngyIZ')
+		expect(getCssText()).toBe('--sxs{--sxs:2 c-Red-gmqXFB c-Size14-hzkWus c-Bold-cQFdVt c-Title-kngyIZ}@media{.c-Red-gmqXFB{color:red}.c-Size14-hzkWus{font-size:14px}.c-Bold-cQFdVt{font-weight:bold}.c-Title-kngyIZ{font-family:monospace}}')
 	})
 })

--- a/packages/react/tests/universal-serialization.js
+++ b/packages/react/tests/universal-serialization.js
@@ -4,14 +4,13 @@ describe('Serialization', () => {
 	const sheet = createStitches()
 	const { styled, getCssText, toString, createTheme } = sheet
 
-	const myComponent = styled.withName('myComponent', 'button', {
+	const myComponent = styled.withName('myComponent')('button', {
 		all: 'unset',
 		font: 'inherit',
 		margin: 0,
 		padding: '0.5em 1em',
 	})
-	const baseSelector = '.c-myComponent-cLikna'
-	const myComponentSelector = `${baseSelector}:where(.c-myComponent-PJLV)`
+	const myComponentSelector = '.c-myComponent-cLikna'
 
 	const myTheme = createTheme({
 		colors: {
@@ -49,7 +48,7 @@ describe('Serialization', () => {
 
 	myComponent.render()
 
-	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{${myThemeSelector}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-myComponent-cLikna c-myComponent-PJLV}@media{${baseSelector}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
+	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{${myThemeSelector}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-myComponent-cLikna}@media{${myComponentSelector}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
 
 	test('Sheets implicitly return their cssText', () => {
 		expect(String(sheet)).toBe(sheetCssText)

--- a/packages/react/tests/universal-serialization.js
+++ b/packages/react/tests/universal-serialization.js
@@ -4,13 +4,14 @@ describe('Serialization', () => {
 	const sheet = createStitches()
 	const { styled, getCssText, toString, createTheme } = sheet
 
-	const myComponent = styled('button', {
+	const myComponent = styled.withName('myComponent', 'button', {
 		all: 'unset',
 		font: 'inherit',
 		margin: 0,
 		padding: '0.5em 1em',
 	})
-	const myComponentSelector = '.c-cLikna'
+	const baseSelector = '.c-myComponent-cLikna'
+	const myComponentSelector = `${baseSelector}:where(.c-myComponent-PJLV)`
 
 	const myTheme = createTheme({
 		colors: {
@@ -48,7 +49,7 @@ describe('Serialization', () => {
 
 	myComponent.render()
 
-	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{${myThemeSelector}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-cLikna}@media{${myComponentSelector}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
+	const sheetCssText = `--sxs{--sxs:0 t-jPkpUS}@media{${myThemeSelector}{--colors-blue:dodgerblue}}--sxs{--sxs:2 c-myComponent-cLikna c-myComponent-PJLV}@media{${baseSelector}{all:unset;font:inherit;margin:0;padding:0.5em 1em}}`
 
 	test('Sheets implicitly return their cssText', () => {
 		expect(String(sheet)).toBe(sheetCssText)


### PR DESCRIPTION
Taking a stab at a different API to this, based on feedback in #916 (see details there).

(Addresses #650)

## Proposed API

Users can use a `withName` utility method to pass in a string as the custom component name, with their calls to `styled`, like so:
```TSX
// Renders as `c-Label-sOm3h4Sh`
const Label = styled.withName("Label")("label", {...})
```

This proposed solution could be combined with a babel plugin, to make friendly class names possible with no extra effort, for those using Babel.

The existing syntax would be unchanged, plus this approach works just as well with `css.withName("Xyz")(...)`, so it's not limited to React only.

---

I feel that this functionality makes debugging much, much easier, so would love to work with the core team to find the right API to get this into production ❤️ .