### PR TITLE
add .js extension to .d.ts files (TS NodeNext fix)

### DIFF
--- a/packages/core/types/config.d.ts
+++ b/packages/core/types/config.d.ts
@@ -1,5 +1,5 @@
-import type * as CSSUtil from './css-util'
-import type Stitches from './stitches'
+import type * as CSSUtil from './css-util.js'
+import type Stitches from './stitches.js'
 
 /** Configuration Interface */
 declare namespace ConfigType {

--- a/packages/core/types/css-util.d.ts
+++ b/packages/core/types/css-util.d.ts
@@ -1,7 +1,7 @@
-import type * as Native from './css'
-import type * as Config from './config'
-import type * as ThemeUtil from './theme'
-import type * as Util from './util'
+import type * as Native from './css.js'
+import type * as Config from './config.js'
+import type * as ThemeUtil from './theme.js'
+import type * as Util from './util.js'
 
 export { Native }
 

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,10 +1,10 @@
-import type Stitches from './stitches'
+import type Stitches from './stitches.js'
 
-import type * as Config from './config'
-import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
+import type * as Config from './config.js'
+import type * as CSSUtil from './css-util.js'
+import type * as StyledComponent from './styled-component.js'
 
-export { $$PropertyValue, $$ScaleValue, $$ThemeValue} from './css-util'
+export { $$PropertyValue, $$ScaleValue, $$ThemeValue} from './css-util.js'
 export type CreateStitches = Config.CreateStitches
 export type CSSProperties = CSSUtil.CSSProperties
 export type DefaultThemeMap = Config.DefaultThemeMap

--- a/packages/core/types/stitches.d.ts
+++ b/packages/core/types/stitches.d.ts
@@ -1,7 +1,7 @@
-import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
-import type * as ThemeUtil from './theme'
-import type * as Util from './util'
+import type * as CSSUtil from './css-util.js'
+import type * as StyledComponent from './styled-component.js'
+import type * as ThemeUtil from './theme.js'
+import type * as Util from './util.js'
 
 /** Remove an index signature from a type */
 export type RemoveIndex<T> = {[k in keyof T as string extends k ? never : number extends k ? never : k]: T[k]}

--- a/packages/core/types/styled-component.d.ts
+++ b/packages/core/types/styled-component.d.ts
@@ -1,4 +1,4 @@
-import type * as Util from './util'
+import type * as Util from './util.js'
 
 /** Returns a new CSS Component. */
 export interface CssComponent<

--- a/packages/react/types/config.d.ts
+++ b/packages/react/types/config.d.ts
@@ -1,5 +1,5 @@
-import type * as CSSUtil from './css-util'
-import type Stitches from './stitches'
+import type * as CSSUtil from './css-util.js'
+import type Stitches from './stitches.js'
 
 /** Configuration Interface */
 declare namespace ConfigType {

--- a/packages/react/types/css-util.d.ts
+++ b/packages/react/types/css-util.d.ts
@@ -1,7 +1,7 @@
-import type * as Native from './css'
-import type * as Config from './config'
-import type * as ThemeUtil from './theme'
-import type * as Util from './util'
+import type * as Native from './css.js'
+import type * as Config from './config.js'
+import type * as ThemeUtil from './theme.js'
+import type * as Util from './util.js'
 
 export { Native }
 

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,10 +1,10 @@
-import type Stitches from './stitches'
+import type Stitches from './stitches.js'
 
-import type * as Config from './config'
-import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
+import type * as Config from './config.js'
+import type * as CSSUtil from './css-util.js'
+import type * as StyledComponent from './styled-component.js'
 
-export { $$PropertyValue, $$ScaleValue, $$ThemeValue } from './css-util'
+export { $$PropertyValue, $$ScaleValue, $$ThemeValue } from './css-util.js'
 export type CreateStitches = Config.CreateStitches
 export type CSSProperties = CSSUtil.CSSProperties
 export type DefaultThemeMap = Config.DefaultThemeMap

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -1,6 +1,6 @@
-import type * as CSSUtil from './css-util'
-import type * as StyledComponent from './styled-component'
-import type * as ThemeUtil from './theme'
+import type * as CSSUtil from './css-util.js'
+import type * as StyledComponent from './styled-component.js'
+import type * as ThemeUtil from './theme.js'
 import type * as Util from './util'
 
 /** Remove an index signature from a type */

--- a/packages/react/types/styled-component.d.ts
+++ b/packages/react/types/styled-component.d.ts
@@ -1,5 +1,5 @@
 import type * as React from 'react'
-import type * as Util from './util'
+import type * as Util from './util.js'
 
 
 export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
@@ -12,7 +12,7 @@ export interface StyledComponent<
 	CSS = {}
 > extends React.ForwardRefExoticComponent<
 	Util.Assign<
-		Type extends IntrinsicElementsKeys | React.ComponentType<any> 
+		Type extends IntrinsicElementsKeys | React.ComponentType<any>
 			? React.ComponentPropsWithRef<Type>
 		: never,
 		TransformProps<Props, Media> & { css?: CSS }
@@ -37,7 +37,7 @@ export interface StyledComponent<
 	>(
 		props: Util.Assign<
 			React.ComponentPropsWithRef<As extends IntrinsicElementsKeys | React.ComponentType<any> ? As : never>,
-			TransformProps<Util.Assign<InnerProps, Props>, Media> & { 
+			TransformProps<Util.Assign<InnerProps, Props>, Media> & {
 				as?: As,
 				css?: {
 					[K in keyof C]: K extends keyof CSS ? CSS[K] : never


### PR DESCRIPTION
fixes type module resolution for NodeNext/ESM in TypeScript

fixes #1084 

TypeScript requires `.d.ts` files to follow ESM module import rules as well, so these files needed extensions added to imported local modules so that types can be resolved when Stitches is used in a project that has `moduleResolution: 'NodeNext'`.