### PR TITLE
fix(package.json): Add 'types/*' to package exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,9 @@
       "import": "./dist/index.mjs",
       "types": "./types/index.d.ts"
     },
+    "./types/*": {
+      "types": "./types/*.d.ts"
+    },
     "./global": "./dist/index.global.js"
   },
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,9 @@
       "import": "./dist/index.mjs",
       "types": "./types/index.d.ts"
     },
+    "./types/*": {
+      "types": "./types/*.d.ts"
+    },
     "./global": "./dist/index.global.js"
   },
   "files": [


### PR DESCRIPTION
This fixes an issue that we are experiencing when setting `moduleResolution` in our tsconfig to `NodeNext`. When this is enabled, the module resolution will only allow importing from paths that are defined within the `exports` config. Because only `types/index.d.ts` is available for import, it is causing these kinds of embedded imports to fail:

```
import("@stitches/react/types/css-util").CSS
```

I think the alternative would be to ensure that all types are exported from the `types/index.d.ts` file.