### PR TITLE
Update deprecated CSSRule.type property.

### DIFF
--- a/packages/core/src/sheet.js
+++ b/packages/core/src/sheet.js
@@ -82,14 +82,14 @@ export const createSheet = (/** @type {DocumentOrShadowRoot} */ root) => {
 				/** @type {CSSStyleRule} Possible indicator rule. */
 				const check = Object(rules[index])
 
-				// a hydratable set of rules will start with a style rule (type: 1), ignore all others
-				if (check.type !== 1) continue
+				// a hydratable set of rules should be a CSSStyleRule, ignore all others
+				if (check.constructor.name !== 'CSSStyleRule') continue
 
 				/** @type {CSSMediaRule} Possible styling group. */
 				const group = Object(rules[index + 1])
 
-				// a hydratable set of rules will follow with a media rule (type: 4), ignore all others
-				if (group.type !== 4) continue
+				// a hydratable set of rules will follow with a CSSMediaRule, ignore all others
+				if (group.constructor.name !== 'CSSMediaRule') continue
 
 				++index
 


### PR DESCRIPTION
The `CSSRule.type` property is deprecated. The recommended alternative is to reference the `constructor.name` property.

>  This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible..

See [CSSRule.type - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule/type)

---

Btw, this is my 1st ever contribution to an open source project. So, I apologize if I did something wrong!