### PR TITLE
Fixed `package.json#exports.types`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,6 @@
   "name": "@stitches/core",
   "version": "1.3.1-1",
   "description": "The modern CSS-in-JS library",
-  "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "types/index.d.ts",
@@ -17,9 +16,9 @@
   "unpkg": "dist/index.global.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs",
-      "types": "./types/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./global": "./dist/index.global.js"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,6 @@
   "name": "@stitches/react",
   "version": "1.3.1-1",
   "description": "The modern CSS-in-JS library",
-  "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "types/index.d.ts",
@@ -17,9 +16,9 @@
   "unpkg": "dist/index.global.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs",
-      "types": "./types/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./global": "./dist/index.global.js"
   },

--- a/packages/stringify/package.json
+++ b/packages/stringify/package.json
@@ -2,7 +2,6 @@
   "name": "@stitches/stringify",
   "version": "1.3.1-1",
   "description": "Converts an object into CSS",
-  "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "typings": "types/index.d.ts",
@@ -10,9 +9,9 @@
   "unpkg": "dist/index.global.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs",
-      "types": "./types/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./global": "./dist/index.global.js"
   },


### PR DESCRIPTION
When relying on `exports.types` for loading types, this condition has to come first. `exports` are order-dependent - tests/loaded from the top to the bottom