### PR TITLE
Fix: Ensure @import rules are always inserted at the top of the stylesheet

### DIFF
--- a/packages/core/src/features/globalCss.js
+++ b/packages/core/src/features/globalCss.js
@@ -24,7 +24,7 @@ export const createGlobalCssFunction = (
 
 				// support @import rules
 				if ('@import' in style) {
-					let importIndex = [].indexOf.call(sheet.sheet.cssRules, sheet.rules.themed.group) - 1
+					let importIndex = 0
 
 					// wrap import in quotes as a convenience
 					for (


### PR DESCRIPTION
This PR addresses an issue in the `createGlobalCssFunction` where `@import` rules might not always be inserted at the top of the stylesheet. According to the CSS specification, all `@import` rules must appear **before any other rules** in a stylesheet. Failing to comply with this requirement results in the browser ignoring the `@import` rules.

### **Problem**:
Previously, the `@import` rules were being inserted just before the `themed.group` marker using the following logic:
```javascript
let importIndex = [].indexOf.call(sheet.sheet.cssRules, sheet.rules.themed.group) - 1;
```
This logic did not guarantee compliance with the CSS requirement for `@import` to always be at the top, as it depended on the position of the `themed.group`.

### **Reference**:
![Screenshot 2024-12-23 at 6 03 29 AM](https://github.com/user-attachments/assets/eb7e1c0e-47ce-4a6f-927f-b9483915ea9e)

https://developer.mozilla.org/en-US/docs/Web/CSS/@import

### **Solution**:
The `importIndex` is now explicitly set to `0`, ensuring that all `@import` rules are added to the top of the stylesheet:
```javascript
let importIndex = 0; // Always insert @import rules at the top
```

This guarantees that all `@import` rules comply with the CSS specification, regardless of other rules or markers in the stylesheet.

---

**Reason for Change**:

- **CSS Specification**:
  - The CSS standard requires `@import` rules to be placed at the top of the stylesheet, before any other types of rules (e.g., style declarations, media queries, keyframes).
  - If `@import` rules appear later in the stylesheet, they are ignored by the browser.

- **Practical Implication**:
  - Placing `@import` rules at the top ensures that external stylesheets are loaded and applied correctly, maintaining the intended style order and cascade.
